### PR TITLE
Save JFrog CLI logs to files

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@docker/docker-mui-theme": "^0.0.4",
+    "@docker/extension-api-client": "^0.2.3",
+    "@docker/extension-api-client-types": "^0.2.3",
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
     "@fontsource/open-sans": "^4.5.8",

--- a/client/src/api/config.ts
+++ b/client/src/api/config.ts
@@ -1,5 +1,5 @@
 import { execOnHost, isWindows, throwErrorAsString } from './utils';
-import {createDockerDesktopClient} from "@docker/extension-api-client";
+import { createDockerDesktopClient } from "@docker/extension-api-client";
 
 const ddClient = createDockerDesktopClient();
 

--- a/client/src/api/image-scan.ts
+++ b/client/src/api/image-scan.ts
@@ -1,6 +1,6 @@
 import { getConfig } from './config';
 import { execOnHost, throwErrorAsString } from './utils';
-import {createDockerDesktopClient} from "@docker/extension-api-client";
+import { createDockerDesktopClient } from "@docker/extension-api-client";
 
 const development: boolean = !process.env.NODE_ENV || process.env.NODE_ENV === 'development';
 const ddClient = createDockerDesktopClient();

--- a/client/src/api/image-scan.ts
+++ b/client/src/api/image-scan.ts
@@ -1,7 +1,9 @@
 import { getConfig } from './config';
 import { execOnHost, throwErrorAsString } from './utils';
+import {createDockerDesktopClient} from "@docker/extension-api-client";
 
 const development: boolean = !process.env.NODE_ENV || process.env.NODE_ENV === 'development';
+const ddClient = createDockerDesktopClient();
 
 /**
  * Scans an image by its tag and returns the results from JFrog CLI in simple-json format.
@@ -50,7 +52,7 @@ export async function getImages(): Promise<any> {
     return testImageData;
   }
 
-  return window.ddClient.docker.listImages();
+  return ddClient.docker.listImages();
 }
 
 const testImageData = [

--- a/client/src/api/setup-env.ts
+++ b/client/src/api/setup-env.ts
@@ -1,5 +1,5 @@
 import { execOnHostAndStreamResult } from './utils';
-import {editJfrogExtensionConfig, JfrogExtensionConfig} from "./config";
+import { editJfrogExtensionConfig, JfrogExtensionConfig } from "./config";
 
 /**
  * Sets up a new JFrog environment. It opens a registration form in a browser window and saves the environments details in the configuration.

--- a/client/src/api/utils.ts
+++ b/client/src/api/utils.ts
@@ -1,4 +1,4 @@
-import {createDockerDesktopClient} from "@docker/extension-api-client";
+import { createDockerDesktopClient } from "@docker/extension-api-client";
 
 const ddClient = createDockerDesktopClient();
 

--- a/client/src/api/utils.ts
+++ b/client/src/api/utils.ts
@@ -1,9 +1,13 @@
+import {createDockerDesktopClient} from "@docker/extension-api-client";
+
+const ddClient = createDockerDesktopClient();
+
 let windowsSystem: boolean | undefined;
 
 export function throwErrorAsString(e: any) {
   let stringErr: string;
   if (e.stderr !== undefined) {
-    stringErr = e.stderr;
+    stringErr = "An error occurred. You can find the logs in your home directory under \".jfrog-docker-desktop-extension/logs\".";
   } else {
     stringErr = e.toString();
   }
@@ -16,11 +20,11 @@ export function throwErrorAsString(e: any) {
  * @param windowsCmd command, binary or script to run on Windows machines.
  * @param args
  */
-export async function execOnHost(unixCmd: string, windowsCmd: string, args?: string[]): Promise<any> {
+export async function execOnHost(unixCmd: string, windowsCmd: string, args: string[]): Promise<any> {
   if (await isWindows()) {
-    return window.ddClient.extension.host.cli.exec(windowsCmd, args);
+    return ddClient.extension.host?.cli.exec(windowsCmd, args);
   }
-  return window.ddClient.extension.host.cli.exec(unixCmd, args);
+  return ddClient.extension.host?.cli.exec(unixCmd, args);
 }
 
 /**
@@ -32,9 +36,9 @@ export async function execOnHost(unixCmd: string, windowsCmd: string, args?: str
  */
 export async function execOnHostAndStreamResult(unixCmd: string, windowsCmd: string, args: string[], options: any): Promise<any> {
   if (await isWindows()) {
-    return window.ddClient.extension.host.cli.exec(windowsCmd, args, options);
+    return ddClient.extension.host?.cli.exec(windowsCmd, args, options);
   }
-  return window.ddClient.extension.host.cli.exec(unixCmd, args, options);
+  return ddClient.extension.host?.cli.exec(unixCmd, args, options);
 }
 
 export async function isWindows(): Promise<boolean> {

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -10,7 +10,7 @@ import { ExtensionConfig } from '../types';
 import { BASIC_AUTH } from '../utils/constants';
 import { SettingsForm } from '../components/Settings/Settings';
 import { LoadingButton } from '@mui/lab';
-import {createDockerDesktopClient} from "@docker/extension-api-client";
+import { createDockerDesktopClient } from "@docker/extension-api-client";
 
 export const LoginPage = () => {
   const [state, setState] = useState<ExtensionConfig>({ authType: BASIC_AUTH });

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -10,18 +10,20 @@ import { ExtensionConfig } from '../types';
 import { BASIC_AUTH } from '../utils/constants';
 import { SettingsForm } from '../components/Settings/Settings';
 import { LoadingButton } from '@mui/lab';
+import {createDockerDesktopClient} from "@docker/extension-api-client";
 
 export const LoginPage = () => {
   const [state, setState] = useState<ExtensionConfig>({ authType: BASIC_AUTH });
   const [isButtonLoading, setButtonLoading] = useState(false);
   const [isLoading, setLoading] = useState(true);
+  const ddClient = createDockerDesktopClient();
   let history = useHistory();
 
   const HandleConnect = async () => {
     setButtonLoading(true);
     if (await Save(state)) {
       history.push('/scan');
-      window.ddClient.desktopUI.toast.success("You're all set!");
+      ddClient.desktopUI.toast.success("You're all set!");
     }
     setButtonLoading(false);
   };

--- a/client/src/pages/Scan.tsx
+++ b/client/src/pages/Scan.tsx
@@ -12,6 +12,7 @@ import { VulnerabilityKeys, Vulnerability } from '../types/Vulnerability';
 import { SeverityIcons } from '../assets/severityIcons/SeverityIcons';
 import { TechIcons } from '../assets/techIcons/TechIcons';
 import PieChartBox, { ChartItemProps } from '../components/PieChart';
+import {createDockerDesktopClient} from "@docker/extension-api-client";
 
 type ScanResults = {
   vulnerabilities: Array<Vulnerability>;
@@ -25,6 +26,7 @@ export const ScanPage = () => {
   const [selectedImage, setSelectedImage] = useState('');
   const [dockerImages, setDockerImages] = useState<string[]>([]);
   const [runningScanId, setRunningScanId] = useState(0);
+  const ddClient = createDockerDesktopClient();
 
   const [scanData, setScanData] = useState<{
     [scanId: string]: {
@@ -60,8 +62,8 @@ export const ScanPage = () => {
           });
         });
         setDockerImages(imagesList);
-      } catch (e) {
-        alert(e);
+      } catch (e: any) {
+        ddClient.desktopUI.toast.error(e.toString());
       }
     };
     getDockerImages();
@@ -78,9 +80,9 @@ export const ScanPage = () => {
       let results: ScanResults = await scanImage(selectedImage);
       console.log(`[${scanId}] scan results for ${selectedImage}`, results);
       saveScanResults(scanId, results);
-    } catch (e) {
+    } catch (e: any) {
       setScanData({ ...scanData, [scanId]: {} });
-      alert(e);
+      ddClient.desktopUI.toast.error(e.toString());
     }
   };
 

--- a/client/src/pages/Scan.tsx
+++ b/client/src/pages/Scan.tsx
@@ -12,7 +12,7 @@ import { VulnerabilityKeys, Vulnerability } from '../types/Vulnerability';
 import { SeverityIcons } from '../assets/severityIcons/SeverityIcons';
 import { TechIcons } from '../assets/techIcons/TechIcons';
 import PieChartBox, { ChartItemProps } from '../components/PieChart';
-import {createDockerDesktopClient} from "@docker/extension-api-client";
+import { createDockerDesktopClient } from "@docker/extension-api-client";
 
 type ScanResults = {
   vulnerabilities: Array<Vulnerability>;

--- a/client/src/pages/SetupEnv.tsx
+++ b/client/src/pages/SetupEnv.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { setupEnv } from '../api/setup-env';
 import { JfrogHeadline } from '../components/JfrogHeadline';
-import {createDockerDesktopClient} from "@docker/extension-api-client";
+import { createDockerDesktopClient } from "@docker/extension-api-client";
 
 export const enum SetupStage {
   Idle,

--- a/client/src/pages/SetupEnv.tsx
+++ b/client/src/pages/SetupEnv.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { setupEnv } from '../api/setup-env';
 import { JfrogHeadline } from '../components/JfrogHeadline';
+import {createDockerDesktopClient} from "@docker/extension-api-client";
 
 export const enum SetupStage {
   Idle,
@@ -14,6 +15,7 @@ export const enum SetupStage {
 
 export const SetupEnvPage = () => {
   let history = useHistory();
+  const ddClient = createDockerDesktopClient();
   const [setupStage, setSetupStage] = useState<SetupStage>(SetupStage.Idle);
 
   const setupEnvHandler = () => {
@@ -21,7 +23,7 @@ export const SetupEnvPage = () => {
     setupEnv(() => setSetupStage(SetupStage.PreparingEnv))
       .then(() => {
         setSetupStage(SetupStage.Done);
-        window.ddClient.desktopUI.toast.success('Please verify your email address within the next 72 hours.');
+        ddClient.desktopUI.toast.success('Please verify your email address within the next 72 hours.');
         history.push('/scan');
       })
       .catch(() => {

--- a/client/src/utils/config.tsx
+++ b/client/src/utils/config.tsx
@@ -1,6 +1,9 @@
 import {Config, getConfig, getJfrogExtensionConfig, saveConfig} from '../api/config';
 import { ExtensionConfig } from '../types';
 import { BASIC_AUTH, ACCESS_TOKEN } from './constants';
+import {createDockerDesktopClient} from "@docker/extension-api-client";
+
+const ddClient = createDockerDesktopClient();
 
 // Save a new JFrog platform configurations
 export const Save = async (user: ExtensionConfig | undefined, skipPasswordValidation?: boolean): Promise<Boolean> => {
@@ -9,29 +12,29 @@ export const Save = async (user: ExtensionConfig | undefined, skipPasswordValida
   }
   try {
     if (!user.url) {
-      window.ddClient.desktopUI.toast.warning("Please enter URL")
+      ddClient.desktopUI.toast.warning("Please enter URL")
       return false;
     }
     if (!user.authType || user.authType === BASIC_AUTH) {
       if (!user.username) {
-        window.ddClient.desktopUI.toast.warning('Please enter username');
+        ddClient.desktopUI.toast.warning('Please enter username');
         return false;
       }
       if (!user.password && !skipPasswordValidation) {
-        window.ddClient.desktopUI.toast.warning('Please enter password');
+        ddClient.desktopUI.toast.warning('Please enter password');
         return false;
       }
     } else {
       if (!user.accessToken && !skipPasswordValidation) {
-        window.ddClient.desktopUI.toast.warning('Please enter access token');
+        ddClient.desktopUI.toast.warning('Please enter access token');
         return false;
       }
     }
 
     await saveConfig(toJfrogCliConfig(user));
     return true;
-  } catch (error) {
-    window.ddClient.desktopUI.toast.error(error);
+  } catch (error: any) {
+    ddClient.desktopUI.toast.error(error.toString());
     return false;
   }
 };

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1174,6 +1174,18 @@
   dependencies:
     "@fontsource/open-sans" "^4.5.1"
 
+"@docker/extension-api-client-types@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@docker/extension-api-client-types/-/extension-api-client-types-0.2.3.tgz#4711e81a18266bf7e8b15734cd7daeb221db1312"
+  integrity sha512-KecgDPmH0Ma7UpwQGAbVQnMCFC9dLvlngWT0jP0uXObxISaPVhHnOzbb+5d+VikazV82Dj7E24ySKJOpKUYHDA==
+
+"@docker/extension-api-client@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@docker/extension-api-client/-/extension-api-client-0.2.3.tgz#902c375860002c3ebc12acf0d43d7a524385cf99"
+  integrity sha512-iqZTGAIOuKLpUqO9fVUAKbHYGs4UUN+AshXM8R31TNGZC9v9ukHuilqoVBpXuwq8MflPEAvLyGuTvdEr2x8EPQ==
+  dependencies:
+    "@docker/extension-api-client-types" "^0.2.3"
+
 "@emotion/babel-plugin@^11.7.1":
   version "11.9.2"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.9.2.tgz#723b6d394c89fb2ef782229d92ba95a740576e95"

--- a/host/unix/runcli.sh
+++ b/host/unix/runcli.sh
@@ -2,7 +2,17 @@
 
 # Runs JFrog CLI with the given arguments. The JFrog CLI's home directory is the extension's home directory.
 
-export JFROG_CLI_HOME_DIR=~/.jfrog-docker-desktop-extension
-export JFROG_CLI_USER_AGENT=jfrog-docker-extension
+HOME_DIR=~/.jfrog-docker-desktop-extension
+LOGS_DIR=$HOME_DIR/logs
+LOG_FILE_PATH=$LOGS_DIR/jfrog-docker-desktop-extension.$(date -n +"%Y-%m-%d.%H-%M-%S").log
 
-$(dirname "$0")/jf $@
+export JFROG_CLI_HOME_DIR=$HOME_DIR
+export JFROG_CLI_USER_AGENT=jfrog-docker-extension
+export JFROG_CLI_LOG_LEVEL=DEBUG
+export CI=true
+
+if [ ! -d $LOGS_DIR ]
+  then mkdir -p $LOGS_DIR
+fi
+
+$(dirname "$0")/jf $@ 2>> $LOG_FILE_PATH

--- a/host/windows/runcli.bat
+++ b/host/windows/runcli.bat
@@ -12,6 +12,6 @@ set CI=true
 
 if not exist %LOGS_DIR% mkdir %LOGS_DIR%
 for /f "tokens=2 delims==" %%I in ('wmic os get localdatetime /format:list') do set datetime=%%I
-set LOG_FILE_PATH=%LOGS_DIR%\jfrog-docker-desktop-extension.%datetime:~0,4%-%datetime:~4,2%-%datetime:~6,2%.%datetime:~8,2%-%datetime:~10,2%-%datetime:~12,2%
+set LOG_FILE_PATH=%LOGS_DIR%\jfrog-docker-desktop-extension.%datetime:~0,4%-%datetime:~4,2%-%datetime:~6,2%.%datetime:~8,2%-%datetime:~10,2%-%datetime:~12,2%.log
 
 %~dp0jf %* 2>> %LOG_FILE_PATH%

--- a/host/windows/runcli.bat
+++ b/host/windows/runcli.bat
@@ -2,7 +2,16 @@
 
 :: Runs JFrog CLI with the given arguments. The JFrog CLI's home directory is the extension's home directory.
 
-set JFROG_CLI_HOME_DIR=%USERPROFILE%\.jfrog-docker-desktop-extension
-set JFROG_CLI_USER_AGENT=jfrog-docker-extension
+set HOME_DIR=%USERPROFILE%\.jfrog-docker-desktop-extension
+set LOGS_DIR=%HOME_DIR%\logs
 
-%~dp0jf %*
+set JFROG_CLI_HOME_DIR=%HOME_DIR%
+set JFROG_CLI_USER_AGENT=jfrog-docker-extension
+set JFROG_CLI_LOG_LEVEL=DEBUG
+set CI=true
+
+if not exist %LOGS_DIR% mkdir %LOGS_DIR%
+for /f "tokens=2 delims==" %%I in ('wmic os get localdatetime /format:list') do set datetime=%%I
+set LOG_FILE_PATH=%LOGS_DIR%\jfrog-docker-desktop-extension.%datetime:~0,4%-%datetime:~4,2%-%datetime:~6,2%.%datetime:~8,2%-%datetime:~10,2%-%datetime:~12,2%
+
+%~dp0jf %* 2>> %LOG_FILE_PATH%


### PR DESCRIPTION
Logs of JFrog CLI commands executed by the extension will be saved in the 'logs' directory inside the extension's home directory.